### PR TITLE
9: Removed `use strict` declerations.

### DIFF
--- a/examples/sample-project/src/a/b/index.js
+++ b/examples/sample-project/src/a/b/index.js
@@ -1,3 +1,16 @@
-'use strict';
+/*
+ *  ____    __    ____  ____  __
+ * (  _ \  /__\  (  _ \(_  _)(  )
+ * )  _ < /(__)\ )  _ < _)(_  )(__
+ * (____/(__)(__)(____/(____)(____)
+ * 
+ * This project is a part of the “Byte-Sized JavaScript” videocast.
+ *
+ * You can watch it at: https://bit.ly/bytesized
+ *
+ * MIT Licensed — See LICENSE.md
+ *
+ * Send your comments, suggestions, and feedback to me@volkan.io
+ */
 
 console.log( 'Hello world!' );

--- a/index.js
+++ b/index.js
@@ -1,3 +1,16 @@
-'use strict';
+/*
+ *  ____    __    ____  ____  __   
+ * (  _ \  /__\  (  _ \(_  _)(  )  
+ * )  _ < /(__)\ )  _ < _)(_  )(__ 
+ * (____/(__)(__)(____/(____)(____)
+ * 
+ * This project is a part of the “Byte-Sized JavaScript” videocast.
+ *
+ * You can watch it at: https://bit.ly/bytesized
+ *
+ * MIT Licensed — See LICENSE.md
+ *
+ * Send your comments, suggestions, and feedback to me@volkan.io
+ */
 
 module.exports = require( './lib' );

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,17 @@
-'use strict';
+/*
+ *  ____    __    ____  ____  __   
+ * (  _ \  /__\  (  _ \(_  _)(  )  
+ * )  _ < /(__)\ )  _ < _)(_  )(__ 
+ * (____/(__)(__)(____/(____)(____)
+ * 
+ * This project is a part of the “Byte-Sized JavaScript” videocast.
+ * 
+ * You can watch it at: https://bit.ly/bytesized
+ * 
+ * MIT Licensed — See LICENSE.md
+ * 
+ * Send your comments, suggestions, and feedback to me@volkan.io 
+ */
 
 const mkdirp = require( 'mkdirp' );
 const walk = require( 'walk' ).walk;


### PR DESCRIPTION
If applied, this commit will remove all the
`use strict` declerations on the Node.JS modules
since ES6 modules use strict mode by default.

This commit is being made to remove redundant code.

Ticket: https://github.com/jsbites/babil/issues/9

This fix should be relatively safe.
No side effects that I can think of.